### PR TITLE
Remove airbrake:deploy from travis deploy commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,3 @@ deploy:
   run:
     - 'bundle exec rake db:migrate'
     - restart
-    - 'bundle exec rake airbrake:deploy'


### PR DESCRIPTION
The command does not work as it is currently run from `.travis.yml`, it requires `TO=<environment>`. Appending this to the command however results in an invalid request to airbrake because no local username is present.
